### PR TITLE
fix: update tldr cache zip location

### DIFF
--- a/common/.tldrrc
+++ b/common/.tldrrc
@@ -1,6 +1,6 @@
 {
   "pagesRepository": "https://github.com/tldr-pages/tldr",
-  "repository": "https://tldr-pages.github.io/assets/tldr.zip",
+  "repository": "https://github.com/tldr-pages/tldr/releases/latest/download/tldr.zip",
   "themes": {
     "simple": {
       "commandName": "bold, underline",


### PR DESCRIPTION
This PR updates the tldr cache location to use GitHub releases instead of the deprecated method of providing assets from the website repo.

See [tldr-pages/tldr@v2.2 (release)](https://github.com/tldr-pages/tldr/releases/tag/v2.2) and https://github.com/tldr-pages/tldr/issues/20832 for more information.